### PR TITLE
[RPLIDAR]: Try to solve LIDAR stuck condition 

### DIFF
--- a/sdk/src/rplidar_driver.cpp
+++ b/sdk/src/rplidar_driver.cpp
@@ -90,7 +90,7 @@ RPlidarDriver * RPlidarDriver::CreateDriver(_u32 drivertype)
     case DRIVER_TYPE_TCP:
          return new RPlidarDriverTCP();
     default:
-        return NULL;
+        return nullptr;
     }
 }
 

--- a/src/rplidar_node.cpp
+++ b/src/rplidar_node.cpp
@@ -64,7 +64,7 @@ rplidar_node::rplidar_node(const rclcpp::NodeOptions & options)
     RPlidarDriver::CreateDriver(rp::standalone::rplidar::DRIVER_TYPE_SERIALPORT);
 
   RCLCPP_INFO(this->get_logger(), "Checking Driver");
-  if (nullptr == m_drv) {
+  if (nullptr == m_drv || m_drv == NULL) {
     /* don't start spinning without a driver object */
     RCLCPP_ERROR(this->get_logger(), "Failed to construct driver");
     rclcpp::shutdown();

--- a/src/rplidar_node.cpp
+++ b/src/rplidar_node.cpp
@@ -96,6 +96,7 @@ rplidar_node::rplidar_node(const rclcpp::NodeOptions & options)
   // get rplidar device info
   if (!getRPLIDARDeviceInfo()) {
     /* don't continue */
+    RCLCPP_ERROR(this->get_logger(), "Error Killing process");
     RPlidarDriver::DisposeDriver(m_drv);
     rclcpp::shutdown();
     return;
@@ -103,6 +104,7 @@ rplidar_node::rplidar_node(const rclcpp::NodeOptions & options)
 
   // check health...
   if (!checkRPLIDARHealth()) {
+    RCLCPP_ERROR(this->get_logger(), "Error Killing process");
     RPlidarDriver::DisposeDriver(m_drv);
     rclcpp::shutdown();
     return;
@@ -255,6 +257,8 @@ bool rplidar_node::checkRPLIDARHealth() const
 void rplidar_node::stop_motor(const EmptyRequest req, EmptyResponse res)
 {
   if (nullptr == m_drv) {
+    RCLCPP_ERROR(this->get_logger(), "Error Killing process");
+    rclcpp::shutdown();
     return;
   }
 
@@ -266,6 +270,8 @@ void rplidar_node::stop_motor(const EmptyRequest req, EmptyResponse res)
 void rplidar_node::start_motor(const EmptyRequest req, EmptyResponse res)
 {
   if (nullptr == m_drv) {
+    RCLCPP_ERROR(this->get_logger(), "Error Killing process");
+    rclcpp::shutdown();
     return;
   }
 
@@ -345,6 +351,8 @@ void rplidar_node::publish_loop()
   double scan_duration = (end_scan_time - start_scan_time).nanoseconds() * 1E-9;
 
   if (op_result != RESULT_OK) {
+    RCLCPP_ERROR(this->get_logger(), "Error Killing process");
+    rclcpp::shutdown();
     return;
   }
   op_result = m_drv->ascendScanData(nodes.get(), count);

--- a/src/rplidar_node.cpp
+++ b/src/rplidar_node.cpp
@@ -117,6 +117,7 @@ rplidar_node::rplidar_node(const rclcpp::NodeOptions & options)
   RCLCPP_INFO(this->get_logger(), "Starting Motor");
   /* start motor */
   m_drv->startMotor();
+  m_drv->startScan(0, 1);
 
   if (!set_scan_mode()) {
     /* set the scan mode */

--- a/src/rplidar_node.cpp
+++ b/src/rplidar_node.cpp
@@ -351,7 +351,7 @@ void rplidar_node::publish_loop()
   double scan_duration = (end_scan_time - start_scan_time).nanoseconds() * 1E-9;
 
   if (op_result != RESULT_OK) {
-    RCLCPP_ERROR(this->get_logger(), "Error Killing process");
+    RCLCPP_ERROR(this->get_logger(), "Error Killing process. No publishing Data");
     rclcpp::shutdown();
     return;
   }

--- a/src/rplidar_node.cpp
+++ b/src/rplidar_node.cpp
@@ -66,6 +66,7 @@ rplidar_node::rplidar_node(const rclcpp::NodeOptions & options)
   if (nullptr == m_drv) {
     /* don't start spinning without a driver object */
     RCLCPP_ERROR(this->get_logger(), "Failed to construct driver");
+    rclcpp::shutdown();
     return;
   }
 
@@ -77,6 +78,7 @@ rplidar_node::rplidar_node(const rclcpp::NodeOptions & options)
         "Error, cannot bind to the specified TCP host '%s:%ud'",
         tcp_ip_.c_str(), static_cast<unsigned int>(tcp_port_));
       RPlidarDriver::DisposeDriver(m_drv);
+      rclcpp::shutdown();
       return;
     }
   } else {
@@ -86,6 +88,7 @@ rplidar_node::rplidar_node(const rclcpp::NodeOptions & options)
         this->get_logger(), "Error, cannot bind to the specified serial port '%s'.",
         serial_port_.c_str());
       RPlidarDriver::DisposeDriver(m_drv);
+      rclcpp::shutdown();
       return;
     }
   }
@@ -94,12 +97,14 @@ rplidar_node::rplidar_node(const rclcpp::NodeOptions & options)
   if (!getRPLIDARDeviceInfo()) {
     /* don't continue */
     RPlidarDriver::DisposeDriver(m_drv);
+    rclcpp::shutdown();
     return;
   }
 
   // check health...
   if (!checkRPLIDARHealth()) {
     RPlidarDriver::DisposeDriver(m_drv);
+    rclcpp::shutdown();
     return;
   }
 
@@ -111,6 +116,7 @@ rplidar_node::rplidar_node(const rclcpp::NodeOptions & options)
     m_drv->stop();
     m_drv->stopMotor();
     RPlidarDriver::DisposeDriver(m_drv);
+    rclcpp::shutdown();
     exit(1);
   }
 
@@ -137,6 +143,7 @@ rplidar_node::~rplidar_node()
   m_drv->stop();
   m_drv->stopMotor();
   RPlidarDriver::DisposeDriver(m_drv);
+  rclcpp::shutdown();
 }
 
 void rplidar_node::publish_scan(


### PR DESCRIPTION
This PR tries to avoid some cases where the rplidar doesn't work at the beginning and it's necessary to relaunch it.

Check changes:
https://github.com/kiwicampus/rplidar_ros/compare/ros2...kiwicampus:experimental/avoid_stuck


### How to test:
- [x] Ensure that your robot has a rplidar
- [x] Enable `NODE_LIDAR` environment variable
- [x] Restart the container using balena 
- [x] Check lidar consumption, use `htop` 
- [x] Check that the topic `ros2 topic echo /scan` is publishing data
- [x] Repeat from step 3 several times ~10